### PR TITLE
Fix: Issue1 缺失外地购买邮寄结算流程

### DIFF
--- a/models.py
+++ b/models.py
@@ -151,17 +151,15 @@ class Order(db.Model):
     
     # 支付方式常量
     PAYMENT_ANZ_TRANSFER = 'anz_transfer'
-    PAYMENT_OTHER_BANK = 'other_bank'
+    PAYMENT_BANK_TRANSFER = 'bank_transfer'
     PAYMENT_CASH = 'cash'
-    PAYMENT_WECHAT = 'wechat'
-    PAYMENT_ALIPAY = 'alipay'
+    PAYMENT_WECHAT_ALIPAY = 'wechat_alipay'
     
     PAYMENT_METHODS = [
         (PAYMENT_ANZ_TRANSFER, 'ANZ银行转账'),
-        (PAYMENT_OTHER_BANK, '跨行转账'),
+        (PAYMENT_BANK_TRANSFER, '跨行转账'),
         (PAYMENT_CASH, '现金支付'),
-        (PAYMENT_WECHAT, '微信支付'),
-        (PAYMENT_ALIPAY, '支付宝')
+        (PAYMENT_WECHAT_ALIPAY, '微信/支付宝')
     ]
     
     # 订单状态常量
@@ -260,8 +258,10 @@ class Order(db.Model):
         return 0.00
     
     def is_payment_required(self):
-        """判断是否需要预付款"""
-        return self.payment_method in ['anz_transfer', 'bank_transfer']
+        """判断是否需要预付款（邮寄订单需要预付款）"""
+        if self.delivery_method == 'shipping':
+            return True  # 邮寄订单都需要预付款
+        return self.payment_method in ['anz_transfer', 'bank_transfer', 'wechat_alipay']
     
     def can_cancel(self):
         """判断订单是否可以取消"""

--- a/templates/order_confirm.html
+++ b/templates/order_confirm.html
@@ -20,7 +20,7 @@
       </div>
       <div class="flex justify-between items-center mb-2">
         <span class="text-lg">邮费:</span>
-        <span id="shippingFee" class="text-lg">待选择交付方式</span>
+        <span id="shippingFee" class="text-lg font-semibold">待选择交付方式</span>
       </div>
       <div class="flex justify-between items-center pt-2 border-t border-gray-200">
         <span class="text-xl font-bold">总计:</span>
@@ -89,19 +89,8 @@
             <label class="block mb-3 font-semibold text-gray-700">
               支付方式 <span class="text-red-500">*</span>
             </label>
-            <div class="space-y-2">
-              <label class="flex items-center">
-                <input type="radio" name="payment_method" value="anz_transfer" class="mr-2" required>
-                <span class="text-gray-700">ANZ银行转账 (推荐)</span>
-              </label>
-              <label class="flex items-center">
-                <input type="radio" name="payment_method" value="bank_transfer" class="mr-2" required>
-                <span class="text-gray-700">跨行转账</span>
-              </label>
-              <label class="flex items-center">
-                <input type="radio" name="payment_method" value="cash_mobile" class="mr-2" required>
-                <span class="text-gray-700">现金/微信/支付宝 (当面交易)</span>
-              </label>
+            <div id="paymentOptions" class="space-y-2">
+              <!-- 支付选项将通过JavaScript动态更新 -->
             </div>
           </div>
         </div>
@@ -187,7 +176,37 @@ document.addEventListener('DOMContentLoaded', function() {
     window.location.href = '{{ url_for("cart") }}';
     return;
   }
+  
+  // 初始化支付选项（默认当面交易）
+  initializePaymentOptions();
 });
+
+// 初始化支付选项
+function initializePaymentOptions() {
+  const paymentOptions = document.getElementById('paymentOptions');
+  // 默认显示当面交易的支付选项
+  paymentOptions.innerHTML = `
+    <label class="flex items-center">
+      <input type="radio" name="payment_method" value="anz_transfer" class="mr-2" required>
+      <span class="text-gray-700">ANZ银行转账</span>
+    </label>
+    <label class="flex items-center">
+      <input type="radio" name="payment_method" value="bank_transfer" class="mr-2" required>
+      <span class="text-gray-700">跨行转账</span>
+    </label>
+    <label class="flex items-center">
+      <input type="radio" name="payment_method" value="cash" class="mr-2" required>
+      <span class="text-gray-700">现金支付 (当面交易)</span>
+    </label>
+    <label class="flex items-center">
+      <input type="radio" name="payment_method" value="wechat_alipay" class="mr-2" required>
+      <span class="text-gray-700">微信/支付宝 (当面交易)</span>
+    </label>
+    <div class="mt-2 p-3 bg-green-50 border border-green-200 rounded text-sm text-green-700">
+      <strong>当面交易说明：</strong>可以选择现金或移动支付，安全便捷
+    </div>
+  `;
+}
 
 // 显示订单商品
 function displayOrderItems() {
@@ -275,18 +294,61 @@ function updateOrderSummary() {
   document.getElementById('total').textContent = `NZD $${total.toFixed(2)}`;
 }
 
-// 更新邮费显示
+// 更新邮费显示和支付选项
 function updateShipping() {
   const deliveryMethod = document.querySelector('input[name="delivery_method"]:checked').value;
   const addressSection = document.getElementById('addressSection');
+  const paymentOptions = document.getElementById('paymentOptions');
   
   // 显示/隐藏地址输入框
   if (deliveryMethod === 'shipping') {
     addressSection.classList.remove('hidden');
     document.getElementById('customer_address').required = true;
+    
+    // 邮寄时的支付选项：只有转账和移动支付
+    paymentOptions.innerHTML = `
+      <label class="flex items-center">
+        <input type="radio" name="payment_method" value="anz_transfer" class="mr-2" required>
+        <span class="text-gray-700">ANZ银行转账 (推荐)</span>
+      </label>
+      <label class="flex items-center">
+        <input type="radio" name="payment_method" value="bank_transfer" class="mr-2" required>
+        <span class="text-gray-700">跨行转账</span>
+      </label>
+      <label class="flex items-center">
+        <input type="radio" name="payment_method" value="wechat_alipay" class="mr-2" required>
+        <span class="text-gray-700">微信/支付宝转账</span>
+      </label>
+      <div class="mt-2 p-3 bg-blue-50 border border-blue-200 rounded text-sm text-blue-700">
+        <strong>邮寄说明：</strong>需要先付款确认后才会安排邮寄，请选择合适的转账方式
+      </div>
+    `;
   } else {
     addressSection.classList.add('hidden');
     document.getElementById('customer_address').required = false;
+    
+    // 当面交易时的支付选项：包括现金
+    paymentOptions.innerHTML = `
+      <label class="flex items-center">
+        <input type="radio" name="payment_method" value="anz_transfer" class="mr-2" required>
+        <span class="text-gray-700">ANZ银行转账</span>
+      </label>
+      <label class="flex items-center">
+        <input type="radio" name="payment_method" value="bank_transfer" class="mr-2" required>
+        <span class="text-gray-700">跨行转账</span>
+      </label>
+      <label class="flex items-center">
+        <input type="radio" name="payment_method" value="cash" class="mr-2" required>
+        <span class="text-gray-700">现金支付 (当面交易)</span>
+      </label>
+      <label class="flex items-center">
+        <input type="radio" name="payment_method" value="wechat_alipay" class="mr-2" required>
+        <span class="text-gray-700">微信/支付宝 (当面交易)</span>
+      </label>
+      <div class="mt-2 p-3 bg-green-50 border border-green-200 rounded text-sm text-green-700">
+        <strong>当面交易说明：</strong>可以选择现金或移动支付，安全便捷
+      </div>
+    `;
   }
   
   // 更新总计

--- a/templates/order_success.html
+++ b/templates/order_success.html
@@ -102,7 +102,9 @@
           <p><span class="font-medium">支付方式:</span>
             {% if order.payment_method == 'anz_transfer' %}ANZ银行转账
             {% elif order.payment_method == 'bank_transfer' %}跨行转账
-            {% else %}现金/移动支付{% endif %}
+            {% elif order.payment_method == 'cash' %}现金支付
+            {% elif order.payment_method == 'wechat_alipay' %}微信/支付宝
+            {% else %}{{ order.payment_method }}{% endif %}
           </p>
           {% if order.customer_address %}
           <p><span class="font-medium">邮寄地址:</span> {{ order.customer_address }}</p>
@@ -136,12 +138,22 @@
         <div>
           <div class="font-medium">支付安排</div>
           <div class="text-blue-600">
-            {% if order.payment_method == 'anz_transfer' %}
-              我会发送ANZ银行账户信息给您，请在确认后进行转账
-            {% elif order.payment_method == 'bank_transfer' %}
-              我会发送银行账户信息给您，请在确认后进行转账
+            {% if order.delivery_method == 'shipping' %}
+              {% if order.payment_method == 'anz_transfer' %}
+                我会发送ANZ银行账户信息给您，请在确认后进行转账，确认到账后安排邮寄
+              {% elif order.payment_method == 'bank_transfer' %}
+                我会发送银行账户信息给您，请在确认后进行转账，确认到账后安排邮寄
+              {% elif order.payment_method == 'wechat_alipay' %}
+                我会发送微信/支付宝收款码给您，请在确认后转账，确认到账后安排邮寄
+              {% endif %}
             {% else %}
-              我们会安排当面交易的时间和地点
+              {% if order.payment_method == 'cash' %}
+                我们会安排当面交易的时间和地点，可以现金支付
+              {% elif order.payment_method == 'wechat_alipay' %}
+                我们会安排当面交易的时间和地点，可以使用微信/支付宝支付
+              {% else %}
+                我会发送银行账户信息给您，也可以选择当面交易时支付
+              {% endif %}
             {% endif %}
           </div>
         </div>
@@ -258,7 +270,7 @@ function printOrder() {
     customer_email: '{{ order.customer_email }}',
     customer_phone: '{{ order.customer_phone or "" }}',
     delivery_method: '{% if order.delivery_method == "pickup" %}当面交易{% else %}邮寄{% endif %}',
-    payment_method: '{% if order.payment_method == "anz_transfer" %}ANZ银行转账{% elif order.payment_method == "bank_transfer" %}跨行转账{% else %}现金/移动支付{% endif %}',
+    payment_method: '{% if order.payment_method == "anz_transfer" %}ANZ银行转账{% elif order.payment_method == "bank_transfer" %}跨行转账{% elif order.payment_method == "cash" %}现金支付{% elif order.payment_method == "wechat_alipay" %}微信/支付宝{% else %}{{ order.payment_method }}{% endif %}',
     customer_address: '{{ order.customer_address or "" }}',
     total_amount: '{{ "%.2f"|format(order.total_amount) }}',
     notes: '{{ order.notes or "" }}'


### PR DESCRIPTION
  ✅ 动态支付选项：
  - 邮寄订单：仅显示ANZ银行转账、跨行转账、微信/支付宝转账
  - 当面交易：显示所有支付方式（包括现金支付）
  - 根据交付方式动态切换支付选项和说明

  ✅ 邮费处理：
  - 邮寄订单自动添加NZD $15邮费
  - 当面交易免邮费
  - 实时更新订单总计

  ✅ 业务逻辑优化：
  - 邮寄订单必须预付款（所有支付方式）
  - 当面交易支持现金支付
  - 更新了支付方式常量和显示逻辑

  ✅ 用户体验改进：
  - 添加了清晰的支付说明
  - 不同交付方式有不同的提示信息
  - 在订单成功页面显示针对性的后续步骤

  ✅ 系统完整性：
  - 更新了订单成功页面的支付方式显示
  - 修正了打印功能中的支付方式显示
  - 测试确认了邮寄和当面交易的完整流程

  现在系统能够正确区分邮寄和当面交易，并为每种交付方式提供合适的支付选项和流程指导。